### PR TITLE
Ozmo930 working

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -43,11 +43,11 @@ def test_custom_command_noargs():
 def test_clean_command():
     c = Clean()
     assert_equals(ElementTree.tostring(c.to_xml()),
-                  b'<ctl td="Clean"><clean speed="standard" type="auto" /></ctl>')  # protocol has attribs in other order
+                  b'<ctl td="Clean"><clean act="s" speed="standard" type="auto" /></ctl>')  # protocol has attribs in other order
     
     c = Clean('edge', 'high')
     assert_equals(ElementTree.tostring(c.to_xml()),
-                  b'<ctl td="Clean"><clean speed="strong" type="border" /></ctl>')  # protocol has attribs in other order
+                  b'<ctl td="Clean"><clean act="s" speed="strong" type="border" /></ctl>')  # protocol has attribs in other order
 
     c = Clean(iotmq=True)
     assert_equals(ElementTree.tostring(c.to_xml()),
@@ -93,13 +93,13 @@ def test_spotarea_command():
 def test_edge_command():
     c = Edge()
     assert_equals(ElementTree.tostring(c.to_xml()),
-                  b'<ctl td="Clean"><clean speed="strong" type="border" /></ctl>')  # protocol has attribs in other order
+                  b'<ctl td="Clean"><clean act="s" speed="strong" type="border" /></ctl>')  # protocol has attribs in other order
 
 
 def test_spot_command():
     c = Spot()
     assert_equals(ElementTree.tostring(c.to_xml()),
-                  b'<ctl td="Clean"><clean speed="strong" type="spot" /></ctl>')  # protocol has attribs in other order
+                  b'<ctl td="Clean"><clean act="s" speed="strong" type="spot" /></ctl>')  # protocol has attribs in other order
 
 
 def test_charge_command():
@@ -111,7 +111,7 @@ def test_charge_command():
 def test_stop_command():
     c = Stop()
     assert_equals(ElementTree.tostring(c.to_xml()),
-                  b'<ctl td="Clean"><clean speed="standard" type="stop" /></ctl>')
+                  b'<ctl td="Clean"><clean act="s" speed="standard" type="stop" /></ctl>')
 
 
 def test_play_sound_command():

--- a/tests/test_ecovacs_xmpp.py
+++ b/tests/test_ecovacs_xmpp.py
@@ -13,6 +13,20 @@ def test_wrap_command():
     c = str(x._wrap_command(Clean().to_xml(), 'E0000000001234567890@126.ecorobot.net/atom'))
     assert_true(search(r'from="20170101abcdefabcdefa@ecouser.net/abcdef12"', c))
     assert_true(search(r'to="E0000000001234567890@126.ecorobot.net/atom"', c))
+    assert_true(search(r'td="Clean" id="',c)) #Check that an id was added to ctl
+
+    cwithid = Clean().to_xml()
+    cwithid.attrib["id"] = "12345678"
+    c = str(x._wrap_command(cwithid, 'E0000000001234567890@126.ecorobot.net/atom'))    
+    assert_true(search(r'td="Clean" id="12345678',c)) #Check that customid was added to ctl
+
+def test_getReqID():
+    x = make_ecovacs_xmpp()
+    rid = x.getReqID("12345678")
+    assert_equals(rid, "12345678") #Check returned ID is the same as provided
+
+    rid2 = x.getReqID()
+    assert_true(len(rid2) >= 8) #Check returned random ID is at least 8 chars
 
 def test_subscribe_to_ctls():
     response = None


### PR DESCRIPTION
- Changed ClientXMPP to login/bind with resource
- Changed clean to always add the action
- Wrap command calls a new getReqID to add an ID to the ctl if needed
  - This was required for the ozmo commands, and shouldn't affect other boths

- Updated tests